### PR TITLE
Issue 57 add GitHub link

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "all-aboard",
   "version": "0.0.3",
   "description": "The Mozilla Firefox onboarding add-on",
+  "homepage": "https://github.com/mozilla/all-aboard",
   "main": "index.js",
   "author": "Mozilla Corporation",
   "engines": {


### PR DESCRIPTION
Adding github link to addon:
<img width="1133" alt="screen shot 2016-06-15 at 10 23 57 am" src="https://cloud.githubusercontent.com/assets/9794516/16075620/9007c00a-32e7-11e6-906f-64342d1bb834.png">

Issue ref: #57 