### PR TITLE
Fix Issue #114 - Multiple Badge Click Advancing Progress

### DIFF
--- a/index.js
+++ b/index.js
@@ -552,14 +552,18 @@ function toggleSidebar() {
     // Ensure that we have not already shown all content items, and that at least 24
     // hours have elapsed since we've shown the last sidebar before continuing to
     // increment the step counter and show the next sidebar.
+
     if (simpleStorage.step !== 5
         && getTimeElapsed(simpleStorage.lastSidebarLaunchTime) >= defaultSidebarInterval) {
-        // get the current sidebar's properties
-        sidebarProps = getSidebarProps();
-        // shows the relevant sidebar
-        showSidebar(sidebarProps);
-        // initialize the about:home pageMod
-        modifyAboutHome(sidebarProps.track, sidebarProps.step);
+        if(simpleStorage.step === undefined || (simpleStorage.tokens !== undefined && simpleStorage.tokens.length === simpleStorage.step))
+        {
+            // get the current sidebar's properties
+            sidebarProps = getSidebarProps();
+            // shows the relevant sidebar
+            showSidebar(sidebarProps);
+            // initialize the about:home pageMod
+            modifyAboutHome(sidebarProps.track, sidebarProps.step);
+        }
     } else {
         // 24 hours has not elapsed since the last content sidebar has been shown so,
         // simply show the current sidebar again. We cannot just simply call .show(),

--- a/index.js
+++ b/index.js
@@ -552,9 +552,11 @@ function toggleSidebar() {
     // Ensure that we have not already shown all content items, and that at least 24
     // hours have elapsed since we've shown the last sidebar before continuing to
     // increment the step counter and show the next sidebar.
-
     if (simpleStorage.step !== 5
         && getTimeElapsed(simpleStorage.lastSidebarLaunchTime) >= defaultSidebarInterval) {
+        // To make sure that we aren't progressing the sidebar when we shouldn't with getSidebarProps(),
+        // we check to see if the first step has been set, or if our current set step is the same as the number of
+        // tokens that have been awarded (tokens are our indicator for the furthest "step" that the user can load at any given point)
         if(simpleStorage.step === undefined || (simpleStorage.tokens !== undefined && simpleStorage.tokens.length === simpleStorage.step))
         {
             // get the current sidebar's properties


### PR DESCRIPTION
I ended up needing to add another if statement before we call getSidebarProps(), as it was progressing the sidebar when it shouldn't. Now that is only called when we are either trying to set the props for the first time, or if the current sidebar step is the same as the number of tokens we've awarded.

Issue ref: #114 

r? @schalkneethling 