### PR TITLE
Issue #92 - Add destroy() to self destruct

### DIFF
--- a/data/js/reward.js
+++ b/data/js/reward.js
@@ -1,0 +1,6 @@
+(function() {
+    var button = document.querySelector('#reward');
+    button.onsubmit = function() {
+        addon.port.emit('intent', 'stickerRedeemed');
+    };
+})();


### PR DESCRIPTION
For some reason, my pushing was not updating my last PR (maybe because I rebased? I'm not sure..), so I had to create a new PR. 

Issue ref: #92

Conditions for calling destroy():
**(done)** 1. When the user has interacted with all 5 content sidebars as well as the final reward sidebar.
**(done)** 2. If a user clicks the "No thanks" link on the /firstrun question modal
**(done)** 3. After 3 weeks of not using the Add-on
4. 2 weeks after content 6 sticker offer regardless if they have taken it

This is now blocked by #178. Once the logic is completed to open the sticker offer, I can add the final 2 week destroy timer after the offer is given, which will be one line of code: startDestroyTimer(1209600000);

@schalkneethling r?
