### PR TITLE
Fix Literally Everything Related to Simple Storage 🔥💻

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ function assignTokens(step, worker) {
     if (tokens.indexOf(token) === -1) {
         tokens.push(token);
         // store the new token
-        utils.store('tokens', tokens);
+        simpleStorage.tokens = tokens;
     }
     // emit the array of tokens to the sidebar
     worker.port.emit('tokens', tokens);
@@ -401,7 +401,7 @@ function assignTokens(step, worker) {
     // the final content item.
     if (step < 5) {
         // update the lastSidebarLaunchTime to now
-        utils.store('lastSidebarLaunchTime', Date.now());
+        simpleStorage.lastSidebarLaunchTime = Date.now();
         // start notification timer
         startNotificationTimer(1);
     } else if (step === 5) {
@@ -605,7 +605,7 @@ function showSidebar(sidebarProps) {
             });
 
             // store the current step we are on
-            utils.store('step', sidebarProps.step);
+            simpleStorage.step = sidebarProps.step;
             // update the distribution id with the current step
             utils.updatePref(sidebarProps.step);
             // start the auto close timer
@@ -653,7 +653,7 @@ function getSidebarProps() {
     assignedToken = false;
 
     // store the current step
-    utils.store('step', contentStep);
+    simpleStorage.step = contentStep;
 
     // set the additional sidebar properties
     sidebarProps.step = contentStep;
@@ -718,7 +718,7 @@ function toggleSidebar() {
         } else {
             // store a property to indicate that the very first sidebar has been
             // triggered from the add-on icon. This will only ever happen once.
-            utils.store('firstIconInteraction', true);
+            simpleStorage.firstIconInteraction = true;
             // this is the first time we are showing a content sidebar.
             sidebarProps = getSidebarProps();
             showSidebar(sidebarProps);
@@ -849,8 +849,8 @@ function modifyFirstrun() {
             }
 
             worker.port.on('dialogSubmit', function(choices) {
-                utils.store('isOnBoarding', choices.isOnBoarding);
-                utils.store('whatMatters', choices.whatMatters);
+                simpleStorage.isOnBoarding = choices.isOnBoarding;
+                simpleStorage.whatMatters = choices.whatMatters;
                 utils.updatePref('-' + choices.whatMatters + '-' + choices.isOnBoarding);
             });
 
@@ -858,7 +858,7 @@ function modifyFirstrun() {
             // before answering any of the questions
             worker.port.on('onboardingDismissed', function(dismissed) {
                 tabs.open('about:newtab');
-                utils.store('onboardingDismissed', dismissed);
+                simpleStorage.onboardingDismissed = dismissed;
                 utils.updatePref('-no-thanks');
                 // user has opted out of onboarding, destroy the addon
                 destroy();
@@ -985,7 +985,7 @@ function modifyNewtab() {
             });
 
             // flag that we've shown the user their data
-            utils.store('seenUserData', true);
+            simpleStorage.seenUserData = true;
         }
     });
 }


### PR DESCRIPTION
# **The Struggle Bus**
After hours and hours of mind-numbing debugging with no real explanation for what is going on, 20,000 different "oh, this has to be it!"'s, and hundreds of packages of fruit snacks, @chrismore and I have found what I consider to be the greatest blunder in the history of our add on development.

Some expected results from this PR: 
1. THE ADD ON PERSISTS BETWEEN SESSIONS!!! :airhorn sirens sound: 🏂🍾🏂🍾🏂🍾
2. We are actually now storing things in simpleStorage
3. @chrismore and I going into cardiac arrest early into our careers (maybe for Chris, just an early death)

## Testing this PR:
In all seriousness, some good things came out of this. We've now figured out how to test locally with jpm. Running `jpm run --binary-args www.mozilla.org/en-US/firefox/46.0/firstrun/ --profile [PROFILE_NAME] --no-copy` will allow information to persist between sessions in testing. Additionally, I've found we can test non-releng packaged xpi's with the funnelcake by simply removing the xpi that they've built with it and replacing that with our current xpi we'd like to test.

## Persistent Sessions = New Bugs:
Some issues will likely come to light now that we are able to persist across sessions, since we have never been able to test this in the past. One obvious one that I saw right off the bat: it seems as though the first token is not stored when it is received, but all the rest are.

## How We Got Here:
The biggest issue we faced was the inability to console log anything. For some reason, nothing I logged to the console was printed, which proved to be a huge blocker in debugging. The second issue was the long process of building an xpi, waiting for Nthomas to build a funnelcake, testing, and realizing something went wrong. We iterated on this process and eventually it led to our success.

First, I was able to narrow the issue down to one if statement within exports.main, namely, https://github.com/FrancescoSTL/all-aboard-1/blob/1704fde30f01ad998df081fb1500e6aa52ed844b/index.js#L1121. After messing around with the conditionals of that statement for a while, I noticed that the condition, typeof simpleStorage.isOnBoarding !== 'undefined', was the source of the problem. After later testing, I also found that the other conditionals within exports.main were not running if they were checking for simpleStorage prefs to be !== 'undefined'. This was our first hint that simple storage was the issue.

After determining that no amount of changing the conditional in that statement, removing the statement entirely, or modifying exports.main would do anything unless we were able to properly identify simpleStorage.isOnBoarding, @chrismore and I moved to OSx to see if we could begin testing in a simpler way than uploading the XPI to docs, downloading, and running in the binary, as we had before. Once we were able to run the XPI in OSx and replicate the session issues of the add on button not showing up (using jpm --profile and --no-copy as given above), we knew that the issue didn't have anything to do with windows or the binary itself.

Finally, I was able to run the binary and get the icon to show up between session due to --no-copy. This allowed me to check if other simpleStorage prefs were undefined. We ran the xpi, went through two steps within the first session, exited, and found that we were reset to the first step upon opening Firefox and the all-aboard sidebar again. This is what led us to look to simpleStorage's sdk where we determined the way we were storing things to be incorrect (https://github.com/mozilla/all-aboard/blob/master/lib/utils.js#L14), which led to the solution in this PR.

It is 9:00 PM PT and time for a beer.

Signing off,
@chrismore and @francescostl
