### PR TITLE
Issue #303 - Notification Not Showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "All Aboard",
-  "name": "all-aboard-dev",
-  "version": "0.0.9",
+  "name": "all-aboard-v1",
+  "version": "1.1.0",
   "description": "The Mozilla Firefox Educational Tool",
   "homepage": "https://github.com/mozilla/all-aboard",
   "repository": "https://github.com/mozilla/all-aboard",


### PR DESCRIPTION
A few things to note with this PR:
1. Something we didn't account for - our timers do not persist between sessions. This means that every time a new session is opened, we need to either (a) start a 60 second timer because the non-persistant timer should've expired or will expire within 60 seconds OR (b) start a timer with the difference between the time elapsed and the total time that there should be between sidebars (essentially starting the timer again as if the session never exited and kept counting down)

Additionally, there was a hole in the logic where users could finish the golden questions, exit FX, and never get onboarded. This is fixed now that all logic to begin the onboarding is moved to the event which handles the golden question submit button.

@schalkneethling @chrismore r?